### PR TITLE
Move from hash-based SPA routing to history.pushstate router

### DIFF
--- a/src/resources/js/admin/app.js
+++ b/src/resources/js/admin/app.js
@@ -88,8 +88,9 @@ const i18n = new VueI18n({
 
 
 const router = new VueRouter({
-    mode: 'hash',
-    routes: getRoutes(i18n)
+    mode: 'history',
+    routes: getRoutes(i18n),
+    base: '/admin'
 });
 
 function setI18nLanguage (lang) {

--- a/src/resources/js/components/BottomNav.vue
+++ b/src/resources/js/components/BottomNav.vue
@@ -23,7 +23,7 @@
                 target="_blank">{{ $t('site.report_bug') }}</a>
             </li>
             <li>
-              <a href="/#/contact">{{ $t('nav.contact') }}</a>
+              <a href="/contact">{{ $t('nav.contact') }}</a>
             </li>
           </ul>
         </div>
@@ -45,10 +45,10 @@
                 target="_blank">GitHub</a>
             </li>
             <li>
-              <a href="/#/privacy">{{ $t('nav.privacy') }}</a>
+              <a href="/privacy">{{ $t('nav.privacy') }}</a>
             </li>
             <li>
-              <a href="/#/terms">{{ $t('nav.terms') }}</a>
+              <a href="/terms">{{ $t('nav.terms') }}</a>
             </li>
           </ul>
         </div>

--- a/src/resources/js/public/app.js
+++ b/src/resources/js/public/app.js
@@ -60,7 +60,7 @@ const i18n = new VueI18n({
 });
 
 const router = new VueRouter({
-    mode: 'hash',
+    mode: 'history',
     routes: getRoutes(i18n),
 });
 Vue.use(VueAnalytics, {id: 'UA-133334351-1', router});
@@ -86,15 +86,16 @@ function setI18nLanguage (lang) {
     return lang;
 }
 
-// eslint-disable-next-line no-console
-console.log('Initializing app...');
-
 // Set language
 setI18nLanguage(window.config.languages.current);
 
-new Vue({
-    el: '#app',
-    render: createElement => createElement(App),
-    router,
-    i18n
-});
+if (document.getElementById('app')) {
+    // eslint-disable-next-line no-console
+    console.log('Initializing app...');
+    new Vue({
+        el: '#app',
+        render: createElement => createElement(App),
+        router,
+        i18n
+    });
+}

--- a/src/resources/js/public/routes.js
+++ b/src/resources/js/public/routes.js
@@ -81,6 +81,28 @@ export function getRoutes(i18n){
                 view: 'improv/history.md'
             }
         },
-        { path: '*', component: PageNotFound }
+
+        // List of legacy routes
+        // These are routes handled by Laravel, ie the views are Blade HTML rendering
+        // Vue.js is still loaded on these pages tho, in order to not 404 them, declare them as empty component routes
+        // Longer term plan is to extract these routes out of Laravel and into Vue
+        {path: '/login'},
+        {path: '/register'},
+        {path: '/password/reset/:token'},
+        {path: '/oauth/scopes'},
+        {path: '/oauth/personal-access-tokens'},
+        {path: '/email/verify'},
+        {path: '/email/verify/:token'},
+        {
+            path: '*',
+            component: PageNotFound,
+            beforeEnter() {
+                // Redirect to a non-Vue 404 page (responded to by Laravel)
+                // This allows us to respond with a 404 Status Code, mainly for SEO
+                // eslint-disable-next-line no-console
+                console.error('Page not found');
+                window.location = '/not-found';
+            }
+        }
     ];
 }

--- a/src/resources/views/auth/login.blade.php
+++ b/src/resources/views/auth/login.blade.php
@@ -55,7 +55,4 @@
         </div>
 
     </div>
-
-
-
 @endsection

--- a/src/resources/views/auth/register.blade.php
+++ b/src/resources/views/auth/register.blade.php
@@ -79,7 +79,7 @@
                                        class="col-md-4 col-form-label text-md-right">{{ __('user.password') }}</label>
 
                                 <div class="col-md-6">
-                                    <input id="password" type="password"
+                                    <input id="password" type="password" autocomplete="off"
                                            class="form-control{{ $errors->has('password') ? ' is-invalid' : '' }}"
                                            name="password" required>
                                     <small id="passwordHelpBlock" class="form-text text-muted">
@@ -100,7 +100,7 @@
                                        class="col-md-4 col-form-label text-md-right">{{ __('user.password_again') }}</label>
 
                                 <div class="col-md-6">
-                                    <input id="password-confirm" type="password" class="form-control"
+                                    <input id="password-confirm" type="password" class="form-control" autocomplete="off"
                                            name="password_confirmation" required>
                                 </div>
                             </div>

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -24,9 +24,6 @@ Route::get('/sitemap.xml', function (){
         ->header('Content-Type','application/xml');
 });
 
-Route::get('/', 'HomeController@index')
-    ->middleware('cache.headers:private;max_age=604800;etag');
-
 Route::get('/maintenance', 'HomeController@maintenance')
     ->middleware('cache.headers:private;max_age=604800;etag')
     ->name('maintenance');
@@ -38,6 +35,7 @@ Route::namespace('Admin')
     ->prefix('admin')
     ->middleware(['auth', 'verified', 'cache.headers:private;max_age=604800;etag'])
     ->group(function () {
+        Route::get('/{wildcard}', 'HomeController@index')->where('wildcard', '.*');
         Route::get('/', 'HomeController@index')->name('home');
     });
 
@@ -48,3 +46,14 @@ Route::group([
 ], function () {
     Route::get('/{locale}', 'HomeController@locale')->name('locale');
 });
+
+Route::get('/not-found',function(){
+    abort(404);
+});
+
+// Catch all route
+// Matches the literal home page (/) as well as anything else (/yelp)
+// Use-case: enable vue-router catch-all routing via history.pushstate
+// https://router.vuejs.org/guide/essentials/history-mode.html#example-server-configurations
+Route::get('{wildcard}', 'HomeController@index')->where('wildcard', '.*')
+    ->middleware('cache.headers:private;max_age=86400;etag');


### PR DESCRIPTION
This enables us the present more "traditional" page URL-s like
https://web.local.improv.ee/events/lhWqYlVYtQToMf7X

instead of using anchors on page.

It is also prereq for SEO and (possible) prerendering.
This will break all previous direct links, which should be few right now
